### PR TITLE
Verbose only if env var is not zero

### DIFF
--- a/f-type/main.c
+++ b/f-type/main.c
@@ -6,7 +6,7 @@
 #include "cpu.h"
 
 int main(int argc, const char * argv[]) {
-    bool verbose = getenv("VERBOSE");
+    const bool verbose = *getenv("VERBOSE") - '0';
     
     if (argc != 2) {
         printf("Usage: %s rom.nes\n", argv[0]);


### PR DESCRIPTION
@sroby this is another simple one to review.

`getenv` returns a `char` pointer, so you need to dereference it order to get the value in the env variable. Also, I subtract by `'0'`, so that` '0'` is `false`.