### PR TITLE
Playing around with P Flags

### DIFF
--- a/src/cpu.c
+++ b/src/cpu.c
@@ -17,11 +17,9 @@ static bool get_p_flag(CPUState *cpu, int flag) {
 }
 
 static void set_p_flag(CPUState *cpu, int flag, bool value) {
-    if (value) {
-        cpu->p |= (1 << flag);
-    } else {
-        cpu->p &= ~(1 << flag);
-    }
+    const int pos_mask = value << flag;
+    const int neg_mask = ~(!value << flag);
+    cpu->p = (cpu->p | pos_mask) & neg_mask;
 }
 
 static void apply_p_nz(CPUState *cpu, uint8_t value) {

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -110,7 +110,7 @@ static void op_PL(CPUState *cpu, const Opcode *op, OpParam param) {
 
 static void op_ADC(CPUState *cpu, const Opcode *op, OpParam param) {
     uint8_t value = get_param_value(cpu, op, param);
-    uint8_t carry = (get_p_flag(cpu, P_C) ? 1 : 0);
+    uint8_t carry = get_p_flag(cpu, P_C);
     set_p_flag(cpu, P_C, ((int)(cpu->a) + (int)carry + (int)value) >= 0x100);
     uint8_t result = cpu->a + carry + value;
     set_p_flag(cpu, P_V, (result & (1 << 7)) != (cpu->a & (1 << 7)));
@@ -120,7 +120,7 @@ static void op_ADC(CPUState *cpu, const Opcode *op, OpParam param) {
 
 static void op_SBC(CPUState *cpu, const Opcode *op, OpParam param) {
     uint8_t value = get_param_value(cpu, op, param);
-    uint8_t carry = (get_p_flag(cpu, P_C) ? 1 : 0);
+    uint8_t carry = get_p_flag(cpu, P_C);
     set_p_flag(cpu, P_C, ((int)(cpu->a) + (int)carry - 1 - (int)value) >= 0);
     uint8_t result = cpu->a + carry - 1 - value;
     set_p_flag(cpu, P_V, (result & (1 << 7)) != (cpu->a & (1 << 7)));
@@ -196,7 +196,7 @@ static void op_ASL(CPUState *cpu, const Opcode *op, OpParam param) {
     shift_left(cpu, op, param, 0);
 }
 static void op_ROL(CPUState *cpu, const Opcode *op, OpParam param) {
-    shift_left(cpu, op, param, (get_p_flag(cpu, P_C) ? 1 : 0));
+    shift_left(cpu, op, param, get_p_flag(cpu, P_C));
 }
 
 static void shift_right(CPUState *cpu, const Opcode *op, OpParam param,
@@ -219,7 +219,7 @@ static void op_LSR(CPUState *cpu, const Opcode *op, OpParam param) {
     shift_right(cpu, op, param, 0);
 }
 static void op_ROR(CPUState *cpu, const Opcode *op, OpParam param) {
-    shift_right(cpu, op, param, (get_p_flag(cpu, P_C) ? 1 << 7 : 0));
+    shift_right(cpu, op, param, get_p_flag(cpu, P_C) << 7);
 }
 
 static void op_JMP(CPUState *cpu, const Opcode *op, OpParam param) {

--- a/src/cpu.h
+++ b/src/cpu.h
@@ -4,14 +4,16 @@
 #include "common.h"
 
 // P flags
-#define P_C 0 // Carry
-#define P_Z 1 // Zero value
-#define P_I 2 // IRQ disable
-#define P_D 3 // Decimal mode (not supported)
-#define P_B 4 // Break
-#define P__ 5 // Unused
-#define P_V 6 // Overflow
-#define P_N 7 // Negative value
+typedef enum {
+    P_C = 1 << 0, // Carry
+    P_Z = 1 << 1, // Zero value
+    P_I = 1 << 2, // IRQ disable
+    P_D = 1 << 3, // Decimal mode (not supported)
+    P_B = 1 << 4, // Break
+    P__ = 1 << 5, // Unused
+    P_V = 1 << 6, // Overflow
+    P_N = 1 << 7  // Negative value
+} PFlag;
 
 // Interrupt Vector Table
 #define IVT_NMI   0xFFFA


### PR DESCRIPTION
Some ideas to simplify P Flags.

@sroby the enum does not need to be declared in the .h, since it does not appear visible outside the cpu itself.